### PR TITLE
Update qtqr.py

### DIFF
--- a/qtqr-1.4/qtqr.py
+++ b/qtqr-1.4/qtqr.py
@@ -504,17 +504,17 @@ class MainWindow(QtGui.QMainWindow):
             self,
             self.trUtf8('Save QRCode'), 
             filter=filterStr
-            )
+            )[0]
         if fn:
-            if not fn.toLower().endsWith(u".png") \
-            and not fn.toLower().endsWith(u".eps") \
-            and not fn.toLower().endsWith(u".svg") \
-            and not fn.toLower().endsWith(u".ansi") \
-            and not fn.toLower().endsWith(u".ansi256") \
-            and not fn.toLower().endsWith(u".ascii") \
-            and not fn.toLower().endsWith(u".asciii") \
-            and not fn.toLower().endsWith(u".utf8") \
-            and not fn.toLower().endsWith(u".ansiutf8"):
+            if not fn.lower().endswith(u".png") \
+            and not fn.lower().endswith(u".eps") \
+            and not fn.lower().endswith(u".svg") \
+            and not fn.lower().endswith(u".ansi") \
+            and not fn.lower().endswith(u".ansi256") \
+            and not fn.lower().endswith(u".ascii") \
+            and not fn.lower().endswith(u".asciii") \
+            and not fn.lower().endswith(u".utf8") \
+            and not fn.lower().endswith(u".ansiutf8"):
                 fn += u".png"
             self.qrencode(unicode(fn))
             if NOTIFY:


### PR DESCRIPTION
Kubuntu 18.04. Version from system rep [qtqr/bionic,bionic,now 1.4~bzr23-1 all]. Using "Save QR-code" button is impossible: application crashes.
By taking 'whereis qtqr' result in my system i found that the application is a python script /usr/bin/qtqr. In this script just need to replace:
string 507 from this:
)
to that:
)[0]
strings 511-519 from this:
            if not fn.toLower().endsWith(u".png") \
            and not fn.toLower().endsWith(u".eps") \
            and not fn.toLower().endsWith(u".svg") \
            and not fn.toLower().endsWith(u".ansi") \
            and not fn.toLower().endsWith(u".ansi256") \
            and not fn.toLower().endsWith(u".ascii") \
            and not fn.toLower().endsWith(u".asciii") \
            and not fn.toLower().endsWith(u".utf8") \
            and not fn.toLower().endsWith(u".ansiutf8"):
To that:
            if not fn.lower().endswith(u".png") \
            and not fn.lower().endswith(u".eps") \
            and not fn.lower().endswith(u".svg") \
            and not fn.lower().endswith(u".ansi") \
            and not fn.lower().endswith(u".ansi256") \
            and not fn.lower().endswith(u".ascii") \
            and not fn.lower().endswith(u".asciii") \
            and not fn.lower().endswith(u".utf8") \
            and not fn.lower().endswith(u".ansiutf8"):
And the error will gone. Sorry for my english. Hope this will usefull to somebody.